### PR TITLE
fix: Railway deployment Linux compatibility

### DIFF
--- a/Sources/App/Services/ContactService.swift
+++ b/Sources/App/Services/ContactService.swift
@@ -171,8 +171,13 @@ final class ContactService: ContactServiceProtocol {
     /// - Returns: Boolean indicating if email format is valid
     private func isValidEmailFormat(_ email: String) -> Bool {
         let emailRegex = #"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$"#
-        let emailPredicate = NSPredicate(format: "SELF MATCHES %@", emailRegex)
-        return emailPredicate.evaluate(with: email)
+        do {
+            let regex = try NSRegularExpression(pattern: emailRegex)
+            let range = NSRange(location: 0, length: email.utf16.count)
+            return regex.firstMatch(in: email, options: [], range: range) != nil
+        } catch {
+            return false
+        }
     }
     
     /// Checks if content contains suspicious patterns that might indicate spam or malicious input.

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -1,7 +1,7 @@
 import Vapor
 import Leaf
 
-public func configure(_ app: Application) throws {
+public func configure(_ app: Application) async throws {
     // Configure Leaf
     app.views.use(.leaf)
     app.leaf.cache.isEnabled = app.environment.isRelease

--- a/Sources/App/main.swift
+++ b/Sources/App/main.swift
@@ -2,7 +2,9 @@ import Vapor
 
 var env = try Environment.detect()
 try LoggingSystem.bootstrap(from: &env)
-let app = Application(env)
-defer { app.shutdown() }
-try configure(app)
-try app.run()
+
+let app = try await Application.make(env)
+defer { Task { try await app.asyncShutdown() } }
+
+try await configure(app)
+try await app.execute()


### PR DESCRIPTION
## Summary
- Fix Railway deployment error caused by NSPredicate not being available in swift-corelibs-foundation on Linux
- Replace NSPredicate email validation with NSRegularExpression for cross-platform compatibility  
- Update to new async Application APIs to resolve deprecation warnings

## Changes Made
- **ContactService.swift**: Replace `NSPredicate(format:)` with `NSRegularExpression` for email validation
- **main.swift**: Use `Application.make()` instead of deprecated `Application()` initializer
- **configure.swift**: Make function async to support new Application lifecycle
- **ErrorHandlingTests.swift**: Update test setup to handle async Application with XCTestExpectation

## Test Results
✅ All 12 integration tests pass
✅ Build completes successfully 
✅ Email validation logic preserved and working

## Deployment Fix
This resolves the Railway deployment error:
```
'init(format:_:)' has been renamed to 'init(block:)': Predicate strings and key-value coding are not supported in swift-corelibs-foundation
```

🤖 Generated with [Claude Code](https://claude.ai/code)